### PR TITLE
Consider configured defaultSchema and added LoadDataChangeMSSQL

### DIFF
--- a/src/java/liquibase/ext/mssql/change/LoadDataChangeMSSQL.java
+++ b/src/java/liquibase/ext/mssql/change/LoadDataChangeMSSQL.java
@@ -1,0 +1,38 @@
+package liquibase.ext.mssql.change;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import liquibase.change.ChangeMetaData;
+import liquibase.change.DatabaseChange;
+import liquibase.database.Database;
+import liquibase.ext.mssql.statement.InsertStatementMSSQL;
+import liquibase.statement.SqlStatement;
+import liquibase.statement.core.InsertStatement;
+
+@DatabaseChange(name = "loadData", description = "Load Data", priority = ChangeMetaData.PRIORITY_DEFAULT, appliesTo = "table")
+public class LoadDataChangeMSSQL extends liquibase.change.core.LoadDataChange {
+    private Boolean identityInsertEnabled;
+
+    public Boolean getIdentityInsertEnabled() {
+	return identityInsertEnabled;
+    }
+
+    public void setIdentityInsertEnabled(Boolean identityInsertEnabled) {
+	this.identityInsertEnabled = identityInsertEnabled;
+    }
+
+    @Override
+    public SqlStatement[] generateStatements(Database database) {
+	SqlStatement[] statements = super.generateStatements(database);
+	List<SqlStatement> wrappedStatements = new ArrayList<SqlStatement>(statements.length);
+	for (SqlStatement statement : statements) {
+	    if (statement instanceof InsertStatement) {
+		wrappedStatements.add(new InsertStatementMSSQL((InsertStatement) statement, identityInsertEnabled));
+	    } else {
+		wrappedStatements.add(statement);
+	    }
+	}
+	return wrappedStatements.toArray(new SqlStatement[0]);
+    }
+}


### PR DESCRIPTION
The pull request consists of the following:
- configured defaultSchema (which may be different from "dbo") will be considered in InsertGenerator
- added LoadDataChangeMSSQL with same behaviour as InsertDataChangeMSSQL (i.e. with ability to turn on identity insert)

Best regards
Jonas