### PR TITLE
bugfix: increased LoadDataChangeMSSQL priority

### DIFF
--- a/src/java/liquibase/ext/mssql/change/LoadDataChangeMSSQL.java
+++ b/src/java/liquibase/ext/mssql/change/LoadDataChangeMSSQL.java
@@ -10,7 +10,7 @@ import liquibase.ext.mssql.statement.InsertStatementMSSQL;
 import liquibase.statement.SqlStatement;
 import liquibase.statement.core.InsertStatement;
 
-@DatabaseChange(name = "loadData", description = "Load Data", priority = ChangeMetaData.PRIORITY_DEFAULT, appliesTo = "table")
+@DatabaseChange(name = "loadData", description = "Load Data", priority = ChangeMetaData.PRIORITY_DATABASE, appliesTo = "table")
 public class LoadDataChangeMSSQL extends liquibase.change.core.LoadDataChange {
     private Boolean identityInsertEnabled;
 


### PR DESCRIPTION
The priority of LoadDataChangeMSSQL was the same as for standard LoadDataChange which lead to undefined behaviour for which of them was chosen. Therefore the priority was increased (according to other extended DataChange classes).