### PR TITLE
Changed identity check statement and upgraded to liquibase 3.4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>org.liquibase</groupId>
             <artifactId>liquibase-core</artifactId>
-            <version>3.3.2</version>
+            <version>3.4.1</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/src/java/liquibase/ext/mssql/change/LoadDataChangeMSSQL.java
+++ b/src/java/liquibase/ext/mssql/change/LoadDataChangeMSSQL.java
@@ -6,8 +6,10 @@ import java.util.List;
 import liquibase.change.ChangeMetaData;
 import liquibase.change.DatabaseChange;
 import liquibase.database.Database;
+import liquibase.ext.mssql.statement.InsertSetStatementMSSQL;
 import liquibase.ext.mssql.statement.InsertStatementMSSQL;
 import liquibase.statement.SqlStatement;
+import liquibase.statement.core.InsertSetStatement;
 import liquibase.statement.core.InsertStatement;
 
 @DatabaseChange(name = "loadData", description = "Load Data", priority = ChangeMetaData.PRIORITY_DATABASE, appliesTo = "table")
@@ -29,6 +31,8 @@ public class LoadDataChangeMSSQL extends liquibase.change.core.LoadDataChange {
 	for (SqlStatement statement : statements) {
 	    if (statement instanceof InsertStatement) {
 		wrappedStatements.add(new InsertStatementMSSQL((InsertStatement) statement, identityInsertEnabled));
+	    } else if(statement instanceof InsertSetStatement) {
+	        wrappedStatements.add(new InsertSetStatementMSSQL((InsertSetStatement) statement, identityInsertEnabled));
 	    } else {
 		wrappedStatements.add(statement);
 	    }

--- a/src/java/liquibase/ext/mssql/sqlgenerator/InsertGenerator.java
+++ b/src/java/liquibase/ext/mssql/sqlgenerator/InsertGenerator.java
@@ -16,13 +16,9 @@ import liquibase.sqlgenerator.SqlGeneratorChain;
 import liquibase.statement.core.InsertStatement;
 
 public class InsertGenerator extends liquibase.sqlgenerator.core.InsertGenerator {
-    public static final String IF_TABLE_HAS_IDENTITY_STATEMENT =
-            "IF EXISTS(select TABLE_NAME\n" +
-            "            from INFORMATION_SCHEMA.COLUMNS\n" +
-            "           where TABLE_SCHEMA = '${schemaName}'\n" +
-            "             and COLUMNPROPERTY(object_id(TABLE_SCHEMA + '.' + TABLE_NAME), COLUMN_NAME, 'IsIdentity') = 1\n" +
-            "             and TABLE_NAME='${tableName}')\n" +
-            "\t${then}\n";
+    public static final String IF_TABLE_HAS_IDENTITY_STATEMENT = "IF ((select objectproperty(\n"
+                    + "            object_id(N'${schemaName}.${tableName}'),\n"
+                    + "           'TableHasIdentity')) = 1)\n" + "\t${then}\n";
 
     @Override
     public int getPriority() {

--- a/src/java/liquibase/ext/mssql/sqlgenerator/InsertSetGenerator.java
+++ b/src/java/liquibase/ext/mssql/sqlgenerator/InsertSetGenerator.java
@@ -1,0 +1,87 @@
+package liquibase.ext.mssql.sqlgenerator;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import liquibase.database.Database;
+import liquibase.database.core.MSSQLDatabase;
+import liquibase.exception.ValidationErrors;
+import liquibase.ext.mssql.statement.InsertSetStatementMSSQL;
+import liquibase.sql.Sql;
+import liquibase.sql.UnparsedSql;
+import liquibase.sqlgenerator.SqlGeneratorChain;
+import liquibase.statement.core.InsertSetStatement;
+import liquibase.statement.core.InsertStatement;
+
+public class InsertSetGenerator extends liquibase.sqlgenerator.core.InsertSetGenerator {
+    public static final String IF_TABLE_HAS_IDENTITY_STATEMENT = "IF ((select objectproperty(\n"
+                    + "            object_id(N'${schemaName}.${tableName}'),\n"
+                    + "           'TableHasIdentity')) = 1)\n" + "\t${then}\n";
+
+    @Override
+    public int getPriority() {
+        return 15;
+    }
+
+    public boolean supports(InsertStatement statement, Database database) {
+        return database instanceof MSSQLDatabase;
+    }
+
+    public ValidationErrors validate(InsertStatement statement, Database database,
+                    SqlGeneratorChain sqlGeneratorChain) {
+        return sqlGeneratorChain.validate(statement, database);
+    }
+
+    @Override
+    public Sql[] generateSql(InsertSetStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
+        Boolean identityInsertEnabled = false;
+        if (statement instanceof InsertSetStatementMSSQL) {
+            identityInsertEnabled = ((InsertSetStatementMSSQL) statement).getIdentityInsertEnabled();
+        }
+        if (identityInsertEnabled == null || !identityInsertEnabled) {
+            return super.generateSql(statement, database, sqlGeneratorChain);
+        }
+        String tableName = database.escapeTableName(statement.getCatalogName(), statement.getSchemaName(),
+                        statement.getTableName());
+        String enableIdentityInsert = "SET IDENTITY_INSERT " + tableName + " ON";
+        String disableIdentityInsert = "SET IDENTITY_INSERT " + tableName + " OFF";
+        String safelyEnableIdentityInsert = ifTableHasIdentityColumn(enableIdentityInsert, statement,
+                        database.getDefaultSchemaName());
+        String safelyDisableIdentityInsert = ifTableHasIdentityColumn(disableIdentityInsert, statement,
+                        database.getDefaultSchemaName());
+
+        List<Sql> sql = new ArrayList<Sql>(Arrays.asList(sqlGeneratorChain.generateSql(statement, database)));
+        sql.add(0, new UnparsedSql(safelyEnableIdentityInsert));
+        sql.add(new UnparsedSql(safelyDisableIdentityInsert));
+        return sql.toArray(new Sql[sql.size()]);
+    }
+
+    private String ifTableHasIdentityColumn(String then, InsertSetStatement statement, String defaultSchemaName) {
+        String tableName = statement.getTableName();
+        String schemaName = statement.getSchemaName();
+        if (schemaName == null) {
+            if (defaultSchemaName != null && !defaultSchemaName.isEmpty()) {
+                schemaName = defaultSchemaName;
+            } else {
+                schemaName = "dbo";
+            }
+        }
+
+        Map<String, String> tokens = new HashMap<String, String>();
+        tokens.put("${tableName}", tableName);
+        tokens.put("${schemaName}", schemaName);
+        tokens.put("${then}", then);
+        return performTokenReplacement(IF_TABLE_HAS_IDENTITY_STATEMENT, tokens);
+    }
+
+    private String performTokenReplacement(String input, Map<String, String> tokens) {
+        String result = input;
+        for (Map.Entry<String, String> entry : tokens.entrySet()) {
+            result = result.replace(entry.getKey(), entry.getValue());
+        }
+        return result;
+    }
+}

--- a/src/java/liquibase/ext/mssql/statement/InsertSetStatementMSSQL.java
+++ b/src/java/liquibase/ext/mssql/statement/InsertSetStatementMSSQL.java
@@ -1,0 +1,25 @@
+package liquibase.ext.mssql.statement;
+
+import liquibase.statement.core.InsertSetStatement;
+
+public class InsertSetStatementMSSQL extends InsertSetStatement {
+    
+    private Boolean identityInsertEnabled;
+    
+    public InsertSetStatementMSSQL(InsertSetStatement statement, Boolean identityInsertEnable) {
+        super(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName());
+        this.identityInsertEnabled = identityInsertEnable;
+    }
+    
+    public InsertSetStatementMSSQL(InsertSetStatement statement, Boolean identityInsertEnable, int batchSize) {
+        super(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName(), batchSize);
+        this.identityInsertEnabled = identityInsertEnable;
+    }
+    
+    public Boolean getIdentityInsertEnabled() {
+        return identityInsertEnabled;
+    }
+    public void setIdentityInsertEnabled(Boolean identityInsertEnabled) {
+        this.identityInsertEnabled = identityInsertEnabled;
+    }
+}


### PR DESCRIPTION
The statement to check if a specific table has an identity column used the global table INFORMATION_SCHEMA.
When running multiple liquibase instances simultaneously (with different schemas, of course) this may lead to a deadlock in MSSQL.
Therefore the statement has been changed to only use specific schema and table to determine if the table has an identity column.
Also check http://stackoverflow.com/questions/87747/how-do-you-determine-what-sql-tables-have-an-identity-column-programatically for different possibilities. Actually the statement has been changed from http://stackoverflow.com/questions/87747/how-do-you-determine-what-sql-tables-have-an-identity-column-programatically#answer-87993 to http://stackoverflow.com/questions/87747/how-do-you-determine-what-sql-tables-have-an-identity-column-programatically#answer-87983.

Furthermore liquibase has been upgraded to 3.4.1. Liquibase introduced InsertSetStatement in 3.4 which lead to some additional code for this statement type.