### PR TITLE
Added support for Sql Server 2005

### DIFF
--- a/src/java/liquibase/ext/mssql/change/CreateIndexChangeMSSQL.java
+++ b/src/java/liquibase/ext/mssql/change/CreateIndexChangeMSSQL.java
@@ -4,6 +4,7 @@ import liquibase.change.ChangeMetaData;
 import liquibase.change.DatabaseChange;
 import liquibase.change.core.CreateIndexChange;
 import liquibase.database.Database;
+import liquibase.ext.mssql.database.MSSQLDatabase;
 import liquibase.ext.mssql.statement.CreateIndexStatementMSSQL;
 import liquibase.statement.SqlStatement;
 import liquibase.statement.core.CreateIndexStatement;
@@ -21,6 +22,11 @@ public class CreateIndexChangeMSSQL extends CreateIndexChange {
 
   public void setIncludedColumns(String includedColumns) {
     this.includedColumns = includedColumns;
+  }
+
+  @Override
+  public boolean supports(Database database) {
+    return database instanceof MSSQLDatabase;
   }
 
   @Override

--- a/src/java/liquibase/ext/mssql/change/DropStoredProcedureChange.java
+++ b/src/java/liquibase/ext/mssql/change/DropStoredProcedureChange.java
@@ -4,6 +4,7 @@ import liquibase.change.AbstractChange;
 import liquibase.change.ChangeMetaData;
 import liquibase.change.DatabaseChange;
 import liquibase.database.Database;
+import liquibase.ext.mssql.database.MSSQLDatabase;
 import liquibase.ext.mssql.statement.DropStoredProcedureStatement;
 import liquibase.statement.SqlStatement;
 
@@ -13,9 +14,14 @@ public class DropStoredProcedureChange extends AbstractChange {
     private String catalogName;
     private String schemaName;
     
-    public DropStoredProcedureChange()
-    {
+    public DropStoredProcedureChange(){
     }
+
+    @Override
+    public boolean supports(Database database) {
+        return database instanceof MSSQLDatabase;
+    }
+
 
     public String getConfirmationMessage() {
         return (new StringBuilder()).append("Stored procedures has been droped").toString();

--- a/src/java/liquibase/ext/mssql/change/InsertDataChangeMSSQL.java
+++ b/src/java/liquibase/ext/mssql/change/InsertDataChangeMSSQL.java
@@ -6,6 +6,7 @@ import java.util.List;
 import liquibase.change.ChangeMetaData;
 import liquibase.change.DatabaseChange;
 import liquibase.database.Database;
+import liquibase.ext.mssql.database.MSSQLDatabase;
 import liquibase.ext.mssql.statement.InsertStatementMSSQL;
 import liquibase.statement.SqlStatement;
 import liquibase.statement.core.InsertStatement;
@@ -21,7 +22,12 @@ public class InsertDataChangeMSSQL extends liquibase.change.core.InsertDataChang
     public void setIdentityInsertEnabled(Boolean identityInsertEnabled) {
         this.identityInsertEnabled = identityInsertEnabled;
     }
-    
+
+    @Override
+    public boolean supports(Database database) {
+        return database instanceof MSSQLDatabase;
+    }
+
     @Override
     public SqlStatement[] generateStatements(Database database) {
         SqlStatement[] statements = super.generateStatements(database);

--- a/src/java/liquibase/ext/mssql/change/LoadDataChangeMSSQL.java
+++ b/src/java/liquibase/ext/mssql/change/LoadDataChangeMSSQL.java
@@ -6,6 +6,8 @@ import java.util.List;
 import liquibase.change.ChangeMetaData;
 import liquibase.change.DatabaseChange;
 import liquibase.database.Database;
+import liquibase.exception.DatabaseException;
+import liquibase.ext.mssql.database.MSSQLDatabase;
 import liquibase.ext.mssql.statement.InsertSetStatementMSSQL;
 import liquibase.ext.mssql.statement.InsertStatementMSSQL;
 import liquibase.statement.SqlStatement;
@@ -25,6 +27,11 @@ public class LoadDataChangeMSSQL extends liquibase.change.core.LoadDataChange {
     }
 
     @Override
+	public boolean supports(Database database) {
+		return database instanceof MSSQLDatabase;
+	}
+
+    @Override
     public SqlStatement[] generateStatements(Database database) {
 	SqlStatement[] statements = super.generateStatements(database);
 	List<SqlStatement> wrappedStatements = new ArrayList<SqlStatement>(statements.length);
@@ -32,11 +39,30 @@ public class LoadDataChangeMSSQL extends liquibase.change.core.LoadDataChange {
 	    if (statement instanceof InsertStatement) {
 		wrappedStatements.add(new InsertStatementMSSQL((InsertStatement) statement, identityInsertEnabled));
 	    } else if(statement instanceof InsertSetStatement) {
-	        wrappedStatements.add(new InsertSetStatementMSSQL((InsertSetStatement) statement, identityInsertEnabled));
+
+	    	if( this.isSupportedMultiValueInserts(database) ){
+				wrappedStatements.add(new InsertSetStatementMSSQL((InsertSetStatement) statement, identityInsertEnabled));
+			}else {
+				wrappedStatements.add(new InsertSetStatementMSSQL((InsertSetStatement) statement, identityInsertEnabled, 0));
+			}
 	    } else {
 		wrappedStatements.add(statement);
 	    }
 	}
 	return wrappedStatements.toArray(new SqlStatement[0]);
     }
+
+	/**
+	 * Sql Server 2005 does not support Insert () values (), () ...
+	 * @param database
+	 * @return
+	 */
+	protected boolean isSupportedMultiValueInserts(Database database){
+
+		try {
+			return database.getDatabaseMajorVersion() > 9;
+		} catch (DatabaseException e) {
+			return true;
+		}
+	}
 }

--- a/src/java/liquibase/ext/mssql/sqlgenerator/CreateIndexGeneratorMSSQL.java
+++ b/src/java/liquibase/ext/mssql/sqlgenerator/CreateIndexGeneratorMSSQL.java
@@ -2,6 +2,7 @@ package liquibase.ext.mssql.sqlgenerator;
 
 import liquibase.change.AddColumnConfig;
 import liquibase.database.Database;
+import liquibase.ext.mssql.database.MSSQLDatabase;
 import liquibase.ext.mssql.statement.CreateIndexStatementMSSQL;
 import liquibase.sql.Sql;
 import liquibase.sql.UnparsedSql;
@@ -28,6 +29,11 @@ public class CreateIndexGeneratorMSSQL extends CreateIndexGenerator {
     }
 
     return super.generateSql(statement, database, sqlGeneratorChain);
+  }
+
+  @Override
+  public boolean supports(CreateIndexStatement statement, Database database) {
+    return database instanceof MSSQLDatabase;
   }
 
   private Sql[] generateMSSQLSql(CreateIndexStatementMSSQL statement, Database database, SqlGeneratorChain sqlGeneratorChain) {

--- a/src/java/liquibase/ext/mssql/statement/InsertSetStatementMSSQL.java
+++ b/src/java/liquibase/ext/mssql/statement/InsertSetStatementMSSQL.java
@@ -8,15 +8,14 @@ public class InsertSetStatementMSSQL extends InsertSetStatement {
     private Boolean identityInsertEnabled;
 
     public InsertSetStatementMSSQL(InsertSetStatement statement, Boolean identityInsertEnable) {
-        super(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName());
-        for (InsertStatement insertStatement : statement.getStatements()) {
-            addInsertStatement(insertStatement);
-        }
-        this.identityInsertEnabled = identityInsertEnable;
+        this(statement, identityInsertEnable, 50);
     }
 
     public InsertSetStatementMSSQL(InsertSetStatement statement, Boolean identityInsertEnable, int batchSize) {
         super(statement.getCatalogName(), statement.getSchemaName(), statement.getTableName(), batchSize);
+        for (InsertStatement insertStatement : statement.getStatements()) {
+            addInsertStatement(insertStatement);
+        }
         this.identityInsertEnabled = identityInsertEnable;
     }
 


### PR DESCRIPTION
Version 9 does not support multivalue insert statements.
Also implemented missing method "supports" in other classes to make sure those ...MSSQL objects are used only for Sql Server.