### PR TITLE
All MSSQL objects must specify that only support this database

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,8 +34,8 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.6.1</version>
                     <configuration>
-                        <source>1.5</source>
-                        <target>1.5</target>
+                        <source>1.6</source>
+                        <target>1.6</target>
                         <optimize>true</optimize>
                         <debug>true</debug>
                         <showDeprecation>true</showDeprecation>

--- a/src/java-test/liquibase/ext/mssql/sqlgenerator/DatabaseSelectionTest.java
+++ b/src/java-test/liquibase/ext/mssql/sqlgenerator/DatabaseSelectionTest.java
@@ -1,0 +1,20 @@
+package liquibase.ext.mssql.sqlgenerator;
+
+import liquibase.database.Database;
+import liquibase.database.DatabaseFactory;
+import liquibase.database.OfflineConnection;
+import liquibase.exception.DatabaseException;
+import org.junit.Test;
+
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.junit.Assert.assertThat;
+
+public class DatabaseSelectionTest {
+
+    @Test
+    public void selectionTest() throws DatabaseException {
+        Database database = DatabaseFactory.getInstance().findCorrectDatabaseImplementation(new OfflineConnection("offline:mssql", null));
+
+        assertThat("Not the expected database", database, instanceOf(liquibase.ext.mssql.database.MSSQLDatabase.class));
+    }
+}

--- a/src/java-test/liquibase/ext/mssql/sqlgenerator/IndexGeneratorTest.java
+++ b/src/java-test/liquibase/ext/mssql/sqlgenerator/IndexGeneratorTest.java
@@ -1,7 +1,10 @@
 package liquibase.ext.mssql.sqlgenerator;
 
 import liquibase.change.AddColumnConfig;
-import liquibase.database.core.MSSQLDatabase;
+import liquibase.database.Database;
+import liquibase.database.DatabaseFactory;
+import liquibase.database.OfflineConnection;
+import liquibase.exception.DatabaseException;
 import liquibase.ext.mssql.statement.CreateIndexStatementMSSQL;
 import liquibase.sql.Sql;
 import liquibase.sqlgenerator.SqlGeneratorFactory;
@@ -12,26 +15,29 @@ import static org.junit.Assert.assertEquals;
 
 public class IndexGeneratorTest {
     @Test
-    public void integrates() {
+    public void integrates() throws DatabaseException {
         final AddColumnConfig firstColumnConfig = new AddColumnConfig();
         firstColumnConfig.setName("id");
         final AddColumnConfig secondColumnConfig = new AddColumnConfig();
         secondColumnConfig.setName("name");
 
+        //Liquibase must find our mssql impl.
+        Database database= DatabaseFactory.getInstance().findCorrectDatabaseImplementation(new OfflineConnection("offline:mssql", null));
+
         CreateIndexStatement statement = new CreateIndexStatement(null, null, null, "TABLE_NAME", true, null, firstColumnConfig, secondColumnConfig);
-        Sql[] sql = SqlGeneratorFactory.getInstance().generateSql(statement, new MSSQLDatabase());
+        Sql[] sql = SqlGeneratorFactory.getInstance().generateSql(statement, database);
         assertEquals("CREATE UNIQUE INDEX ON [TABLE_NAME]([id], [name])", sql[0].toSql());
 
         statement = new CreateIndexStatementMSSQL(statement, "included, includedtoo", null);
-        sql = SqlGeneratorFactory.getInstance().generateSql(statement, new MSSQLDatabase());
+        sql = SqlGeneratorFactory.getInstance().generateSql(statement, database);
         assertEquals("CREATE UNIQUE INDEX ON [TABLE_NAME]([id], [name]) INCLUDE ([included], [includedtoo])", sql[0].toSql());
 
         statement = new CreateIndexStatementMSSQL(statement, null, 50);
-        sql = SqlGeneratorFactory.getInstance().generateSql(statement, new MSSQLDatabase());
+        sql = SqlGeneratorFactory.getInstance().generateSql(statement, database);
         assertEquals("CREATE UNIQUE INDEX ON [TABLE_NAME]([id], [name]) WITH (FILLFACTOR = 50)", sql[0].toSql());
 
         statement = new CreateIndexStatementMSSQL(statement, "included, includedtoo", 50);
-        sql = SqlGeneratorFactory.getInstance().generateSql(statement, new MSSQLDatabase());
+        sql = SqlGeneratorFactory.getInstance().generateSql(statement, database);
         assertEquals("CREATE UNIQUE INDEX ON [TABLE_NAME]([id], [name]) INCLUDE ([included], [includedtoo]) WITH (FILLFACTOR = 50)", sql[0].toSql());
     }
 }

--- a/src/java-test/liquibase/ext/mssql/sqlgenerator/InsertGeneratorTest.java
+++ b/src/java-test/liquibase/ext/mssql/sqlgenerator/InsertGeneratorTest.java
@@ -1,6 +1,10 @@
 package liquibase.ext.mssql.sqlgenerator;
 
+import liquibase.database.Database;
+import liquibase.database.DatabaseFactory;
+import liquibase.database.OfflineConnection;
 import liquibase.database.core.MSSQLDatabase;
+import liquibase.exception.DatabaseException;
 import liquibase.ext.mssql.statement.InsertStatementMSSQL;
 import liquibase.sql.Sql;
 import liquibase.sqlgenerator.SqlGeneratorFactory;
@@ -12,14 +16,18 @@ import static org.junit.Assert.assertFalse;
 
 public class InsertGeneratorTest {
     @Test
-    public void integrates() {
+    public void integrates() throws DatabaseException {
+
+        //Liquibase must find our mssql impl.
+        Database database= DatabaseFactory.getInstance().findCorrectDatabaseImplementation(new OfflineConnection("offline:mssql", null));
+
         InsertStatement statement = new InsertStatement(null, null, "TABLE_NAME");
         statement.addColumnValue("id", 1);
         statement.addColumnValue("name", "asdf");
         
         statement = new InsertStatementMSSQL(statement, true);
 
-        Sql[] sql = SqlGeneratorFactory.getInstance().generateSql(statement, new MSSQLDatabase());
+        Sql[] sql = SqlGeneratorFactory.getInstance().generateSql(statement, database);
         assertEquals(3, sql.length);
 
         for (Sql currentSql : sql) {

--- a/src/java-test/liquibase/ext/mssql/sqlgenerator/InsertGeneratorTest.java
+++ b/src/java-test/liquibase/ext/mssql/sqlgenerator/InsertGeneratorTest.java
@@ -3,7 +3,6 @@ package liquibase.ext.mssql.sqlgenerator;
 import liquibase.database.Database;
 import liquibase.database.DatabaseFactory;
 import liquibase.database.OfflineConnection;
-import liquibase.database.core.MSSQLDatabase;
 import liquibase.exception.DatabaseException;
 import liquibase.ext.mssql.statement.InsertStatementMSSQL;
 import liquibase.sql.Sql;

--- a/src/java-test/liquibase/ext/mssql/sqlgenerator/PrimaryKeyGeneratorTest.java
+++ b/src/java-test/liquibase/ext/mssql/sqlgenerator/PrimaryKeyGeneratorTest.java
@@ -4,7 +4,6 @@ import liquibase.database.Database;
 import liquibase.database.DatabaseFactory;
 import liquibase.database.OfflineConnection;
 import liquibase.exception.DatabaseException;
-import liquibase.ext.mssql.database.MSSQLDatabase;
 import liquibase.ext.mssql.statement.AddPrimaryKeyStatementMSSQL;
 import liquibase.sql.Sql;
 import liquibase.sqlgenerator.SqlGeneratorFactory;

--- a/src/java-test/liquibase/ext/mssql/sqlgenerator/PrimaryKeyGeneratorTest.java
+++ b/src/java-test/liquibase/ext/mssql/sqlgenerator/PrimaryKeyGeneratorTest.java
@@ -1,6 +1,10 @@
 package liquibase.ext.mssql.sqlgenerator;
 
-import liquibase.database.core.MSSQLDatabase;
+import liquibase.database.Database;
+import liquibase.database.DatabaseFactory;
+import liquibase.database.OfflineConnection;
+import liquibase.exception.DatabaseException;
+import liquibase.ext.mssql.database.MSSQLDatabase;
 import liquibase.ext.mssql.statement.AddPrimaryKeyStatementMSSQL;
 import liquibase.sql.Sql;
 import liquibase.sqlgenerator.SqlGeneratorFactory;
@@ -11,19 +15,23 @@ import static org.junit.Assert.assertEquals;
 
 public class PrimaryKeyGeneratorTest {
   @Test
-  public void integrates() {
+  public void integrates() throws DatabaseException {
+
+    //Liquibase must find our mssql impl.
+    Database database= DatabaseFactory.getInstance().findCorrectDatabaseImplementation(new OfflineConnection("offline:mssql", null));
+
     AddPrimaryKeyStatement statement = new AddPrimaryKeyStatement("myCat", "mySchema", "myTable", "myCol", "myConstraint");
     statement.setClustered(true);
 
-    Sql[] sql = SqlGeneratorFactory.getInstance().generateSql(statement, new MSSQLDatabase());
+    Sql[] sql = SqlGeneratorFactory.getInstance().generateSql(statement, database);
     assertEquals("ALTER TABLE [mySchema].[myTable] ADD CONSTRAINT [myConstraint] PRIMARY KEY ([myCol])", sql[0].toSql());
 
     statement = new AddPrimaryKeyStatementMSSQL(statement, null);
-    sql = SqlGeneratorFactory.getInstance().generateSql(statement, new MSSQLDatabase());
+    sql = SqlGeneratorFactory.getInstance().generateSql(statement, database);
     assertEquals("ALTER TABLE [mySchema].[myTable] ADD CONSTRAINT [myConstraint] PRIMARY KEY ([myCol])", sql[0].toSql());
 
     statement = new AddPrimaryKeyStatementMSSQL(statement, 50);
-    sql = SqlGeneratorFactory.getInstance().generateSql(statement, new MSSQLDatabase());
+    sql = SqlGeneratorFactory.getInstance().generateSql(statement, database);
     assertEquals("ALTER TABLE [mySchema].[myTable] ADD CONSTRAINT [myConstraint] PRIMARY KEY ([myCol]) WITH (FILLFACTOR = 50)", sql[0].toSql());
   }
 }

--- a/src/java/liquibase/ext/mssql/change/CreateIndexChangeMSSQL.java
+++ b/src/java/liquibase/ext/mssql/change/CreateIndexChangeMSSQL.java
@@ -48,4 +48,9 @@ public class CreateIndexChangeMSSQL extends CreateIndexChange {
 
     return extendedStatements.toArray(new SqlStatement[0]);
   }
+
+  @Override
+  public boolean supports(Database database) {
+    return database instanceof MSSQLDatabase;
+  }
 }

--- a/src/java/liquibase/ext/mssql/change/DropStoredProcedureChange.java
+++ b/src/java/liquibase/ext/mssql/change/DropStoredProcedureChange.java
@@ -4,6 +4,7 @@ import liquibase.change.AbstractChange;
 import liquibase.change.ChangeMetaData;
 import liquibase.change.DatabaseChange;
 import liquibase.database.Database;
+import liquibase.ext.mssql.database.MSSQLDatabase;
 import liquibase.ext.mssql.statement.DropStoredProcedureStatement;
 import liquibase.statement.SqlStatement;
 
@@ -44,5 +45,10 @@ public class DropStoredProcedureChange extends AbstractChange {
     public void setSchemaName(String schemaName)
     {
         this.schemaName = schemaName;
+    }
+
+    @Override
+    public boolean supports(Database database) {
+        return database instanceof MSSQLDatabase;
     }
 }

--- a/src/java/liquibase/ext/mssql/change/InsertDataChangeMSSQL.java
+++ b/src/java/liquibase/ext/mssql/change/InsertDataChangeMSSQL.java
@@ -39,4 +39,9 @@ public class InsertDataChangeMSSQL extends liquibase.change.core.InsertDataChang
         }
         return wrappedStatements.toArray(new SqlStatement[0]);
     }
+
+    @Override
+    public boolean supports(Database database) {
+        return database instanceof MSSQLDatabase;
+    }
 }

--- a/src/java/liquibase/ext/mssql/change/LoadDataChangeMSSQL.java
+++ b/src/java/liquibase/ext/mssql/change/LoadDataChangeMSSQL.java
@@ -43,4 +43,9 @@ public class LoadDataChangeMSSQL extends liquibase.change.core.LoadDataChange {
 	}
 	return wrappedStatements.toArray(new SqlStatement[0]);
     }
+
+	@Override
+	public boolean supports(Database database) {
+		return database instanceof MSSQLDatabase;
+	}
 }

--- a/src/java/liquibase/ext/mssql/sqlgenerator/AddPrimaryKeyGeneratorMSSQL.java
+++ b/src/java/liquibase/ext/mssql/sqlgenerator/AddPrimaryKeyGeneratorMSSQL.java
@@ -1,6 +1,7 @@
 package liquibase.ext.mssql.sqlgenerator;
 
 import liquibase.database.Database;
+import liquibase.ext.mssql.database.MSSQLDatabase;
 import liquibase.ext.mssql.statement.AddPrimaryKeyStatementMSSQL;
 import liquibase.sql.Sql;
 import liquibase.sql.UnparsedSql;
@@ -75,4 +76,10 @@ public class AddPrimaryKeyGeneratorMSSQL extends AddPrimaryKeyGenerator {
         new UnparsedSql(sql, getAffectedPrimaryKey(statement))
     };
   }
+
+  @Override
+  public boolean supports(AddPrimaryKeyStatement statement, Database database) {
+    return database instanceof MSSQLDatabase;
+  }
+
 }

--- a/src/java/liquibase/ext/mssql/sqlgenerator/CreateIndexGeneratorMSSQL.java
+++ b/src/java/liquibase/ext/mssql/sqlgenerator/CreateIndexGeneratorMSSQL.java
@@ -2,6 +2,7 @@ package liquibase.ext.mssql.sqlgenerator;
 
 import liquibase.change.AddColumnConfig;
 import liquibase.database.Database;
+import liquibase.ext.mssql.database.MSSQLDatabase;
 import liquibase.ext.mssql.statement.CreateIndexStatementMSSQL;
 import liquibase.sql.Sql;
 import liquibase.sql.UnparsedSql;
@@ -78,5 +79,10 @@ public class CreateIndexGeneratorMSSQL extends CreateIndexGenerator {
     }
 
     return new Sql[]{new UnparsedSql(builder.toString(), getAffectedIndex(statement))};
+  }
+
+  @Override
+  public boolean supports(CreateIndexStatement statement, Database database) {
+    return database instanceof MSSQLDatabase;
   }
 }


### PR DESCRIPTION
All MSSQL objects must specify that only support this database else Liquibase will list all available ones (for each action) and get one sorted by priority; nothing ensures it gets the appropiate one. This problem happened to me when using MsSQL and added support to Postgresql using the same liquibase script.

Note: Upgraded pom.xml to use java 1.6 as at least in InsertGenerator.java:61 the String.isEmpty() is used (an it's annotated @since 1.6)

Note 2: It seems that InsertGenerator, InsertSetGenerator, DropSotredProcedureChange, DropStoredProcedureStatment are missing the suffix 'MSSQL'